### PR TITLE
Modernize config format and remove PR rate limits

### DIFF
--- a/ansibleCollection.json
+++ b/ansibleCollection.json
@@ -1,8 +1,9 @@
 {
-   "regexManagers":[
+   "customManagers":[
       {
-         "fileMatch":[
-            "^\\.zuul\\.yaml$"
+         "customType":"regex",
+         "managerFilePatterns":[
+            "/^\\.zuul\\.yaml$/"
          ],
          "matchStrings":[
             "ansible_molecule_ansible_version: \\\"(?<currentValue>.*?)\\\""
@@ -14,7 +15,7 @@
 
    "packageRules":[
       {
-         "matchPaths": ["**/.zuul.yaml"],
+         "matchFileNames": ["**/.zuul.yaml"],
          "groupName": "test-role"
       }
    ]

--- a/default.json
+++ b/default.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "config:base"
+    "config:recommended"
   ],
   "commitBody": "Signed-off-by: Renovate Bot <bot@renovateapp.com>",
   "dependencyDashboard": true,

--- a/default.json
+++ b/default.json
@@ -4,5 +4,7 @@
   ],
   "commitBody": "Signed-off-by: Renovate Bot <bot@renovateapp.com>",
   "dependencyDashboard": true,
-  "labels": ["renovate"]
+  "labels": ["renovate"],
+  "prHourlyLimit": 0,
+  "prConcurrentLimit": 0
 }

--- a/docker.json
+++ b/docker.json
@@ -1,8 +1,9 @@
 {
-   "regexManagers":[
+   "customManagers":[
       {
-         "fileMatch":[
-            "Containerfile"
+         "customType":"regex",
+         "managerFilePatterns":[
+            "/Containerfile/"
          ],
          "matchStrings":[
             "'(?<depName>pip)==(?<currentValue>.*?)'"
@@ -10,8 +11,9 @@
          "datasourceTemplate":"pypi"
       },
       {
-         "fileMatch":[
-            "Containerfile"
+         "customType":"regex",
+         "managerFilePatterns":[
+            "/Containerfile/"
          ],
          "matchStrings":[
             "ARG VERSION=(?<currentValue>.*?)  # renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\n"

--- a/python.json
+++ b/python.json
@@ -1,6 +1,6 @@
 {
   "pip_requirements": {
-    "fileMatch": [
+    "managerFilePatterns": [
       "docs/requirements.txt",
       "documentation/requirements.txt",
       "molecule/requirements.txt",


### PR DESCRIPTION
Two stacked changes to the shared Renovate presets.

## 1. Convert presets to the new Renovate config format

Renovate deprecated several configuration keys (warned under `--strict`,
to be removed eventually). Migrate the shared presets so repositories
that extend them stay valid:

- `default.json`: `config:base` → `config:recommended`
- `ansibleCollection.json`, `docker.json`: `regexManagers` → `customManagers`
  (with `"customType": "regex"`), `fileMatch` → `managerFilePatterns`
  (wrapped in slashes to stay regex and keep matching subdirectory paths)
- `ansibleCollection.json`: `matchPaths` → `matchFileNames`
- `python.json`: `fileMatch` → `managerFilePatterns` (literal paths, now globs)

## 2. Remove PR rate limits in the default preset

Repos currently inherit `prHourlyLimit: 2` from `config:recommended`,
which (together with `prConcurrentLimit`) caps how many detected updates
become PRs — the rest pile up in each repo's **Rate-Limited** dashboard
section and must be released manually.

Set `prHourlyLimit: 0` and `prConcurrentLimit: 0` (unlimited) in the
shared `default.json` so the cap no longer applies org-wide. These are
plain Renovate options honoured by the Mend-hosted app, independent of
the hosted tier's job scheduling. They can be dialled down to a sane cap
later if unlimited proves too aggressive.

## Validation

All presets pass `renovate-config-validator --strict` (renovate 42.99.0)
with no errors or deprecation warnings.

## Notes

- Related issue:
  - osism/issues#1384
- Expect a one-time PR flood on the first run after merge, as existing
  rate-limited backlogs are released at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)