### PR TITLE
Delay third-party update PRs by three days

### DIFF
--- a/default.json
+++ b/default.json
@@ -6,5 +6,35 @@
   "dependencyDashboard": true,
   "labels": ["renovate"],
   "prHourlyLimit": 0,
-  "prConcurrentLimit": 0
+  "prConcurrentLimit": 0,
+  "minimumReleaseAge": "3 days",
+  "internalChecksFilter": "strict",
+  "osvVulnerabilityAlerts": true,
+  "packageRules": [
+    {
+      "description": "Exempt OSISM's own releases from the 3-day delay so the team can bump fast",
+      "matchPackageNames": [
+        "osism",
+        "osism.*",
+        "netbox-manager",
+        "openstack-image-manager",
+        "openstack-flavor-manager",
+        "registry.osism.tech/osism/**"
+      ],
+      "minimumReleaseAge": null
+    },
+    {
+      "description": "Throttle high-frequency third-party releasers to weekly batches; security fixes bypass schedule automatically",
+      "matchPackageNames": [
+        "ghcr.io/astral-sh/uv",
+        "boto3",
+        "fastapi",
+        "typer",
+        "cryptography",
+        "setuptools",
+        "@types/node"
+      ],
+      "schedule": ["before 9am on monday"]
+    }
+  ]
 }


### PR DESCRIPTION
## What

Tame Renovate PR noise by delaying third-party update PRs until a release has been out **3 days**, while keeping fast paths where they matter.

- `minimumReleaseAge: "3 days"` + `internalChecksFilter: "strict"` — withhold update PRs (not just flag them pending) until a release matures 3 days.
- **Exempt OSISM's own releases** (`minimumReleaseAge: null`): the `osism` PyPI package, the `osism.*` collections, and own container images under `registry.osism.tech/osism/**` (scoped to that path so the `/dockerhub/` and `/kolla/` mirrors aren't caught).
- **Throttle high-frequency third-party releasers** to a weekly schedule: `uv`, `boto3`, `fastapi`, `typer`, `cryptography`, `setuptools`, `@types/node`. Picked from 6 months of Renovate PR history (distinct versions chased × repo spread), not by gut feel.
- `osvVulnerabilityAlerts: true` so security detection covers PyPI via osv.dev, not just GitHub advisories.

## Why

Replaces the discussed re-enabling of rate limits. A delay keeps us current on security bumps while cutting volume — security fixes bypass **both** `minimumReleaseAge` and `schedule` automatically, so nothing here slows a CVE fix for any package.

## Validation

All three layers checked against `osism/osism-kubernetes` (it uses both an `osism.*` collection and `uv`), with this branch preset active (confirmed via `default.json?ref=minimum-release-age`).

**1. Config** — `renovate-config-validator default.json` → validated successfully.

**2. Matching** (minimatch, against real dep names) — OSISM's own (`osism`, `osism.commons`, `osism.services`, `registry.osism.tech/osism/*`) match the exempt rule; the `/dockerhub/` and `/kolla/` mirrors correctly do **not**; the throttle list catches `uv`/`boto3`/`cryptography`/`@types/node` but leaves `ansible`/`osism` alone. Live `renovate --dry-run` confirms the depNames are exactly these: `osism.commons` (`galaxy-collection`), `ghcr.io/astral-sh/uv` (`docker`), mirror `registry.osism.tech/dockerhub/python`.

**3. Behavior** (live `renovate --dry-run=full`):
- *Delay holds third-party PRs* — real update branches were withheld:
  > `Branch updating is skipped because internalChecksFilter was not met (branch=renovate/ghcr.io-astral-sh-uv-0.x)`
  > `Branch updating is skipped because internalChecksFilter was not met (branch=renovate/python-3.x)`
- *Exemption releases them* — A/B run applying `minimumReleaseAge: null` to a dep with a real pending update (`uv`) flips it from withheld to allowed, while a non-exempt control (`python`) stays held:
  > `Branch is not pending, removing pending upgrades (branch=renovate/ghcr.io-astral-sh-uv-0.x)`
  > `Processing 3 branches: …, renovate/ghcr.io-astral-sh-uv-0.x, renovate/python-3.x` → result `pr-edited`

  This is exactly the override the OSISM exempt rule uses; `osism.commons` itself shows no bump only because it is already on the latest release (18 days old), not due to any failure.

## Side observation (not part of this PR)

In the dry-run, Renovate's `galaxy-collection` lookup against the bare `https://galaxy.ansible.com` builds `/v3/…` and gets HTML back; the working API base is `/api/v3/…`. Collection bumps still happen in production, but if collection lookups ever start failing org-wide, the registryUrl missing `/api` is the place to look.

The throttle list is a judgment call — easy to trim to just the org-wide noisemakers (`uv`, `typer`) if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)