### PR TITLE
Add regex versioning for OSISM -rN image tags

### DIFF
--- a/default.json
+++ b/default.json
@@ -35,6 +35,14 @@
         "@types/node"
       ],
       "schedule": ["before 9am on monday"]
+    },
+    {
+      "description": "OSISM-rebuilt images carry a Bitnami-style -rN downstream revision (same upstream version, rebuilt by OSISM with local patches). Use regex versioning so Renovate tracks the -rN revision and future upstream bumps; the default docker versioning would treat -rN as an opaque compatibility suffix (like -alpine) and never bump it. The -r part is optional so a bare X.Y.Z pin is still parsed and upgraded to X.Y.Z-r1. Scope to images that actually use this scheme; do not widen to registry.osism.tech/osism/** (most images use date-based or codename tags this regex would reject).",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "registry.osism.tech/osism/ara-server"
+      ],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?:-r(?<build>\\d+))?$"
     }
   ]
 }


### PR DESCRIPTION
## Problem

OSISM rebuilds some upstream container images with local patches and pushes them
under a Bitnami-style downstream revision suffix, e.g. `osism/ara-server:1.7.5-r1`.
The revision lets a fix change the image without an upstream version bump while
still minting a fresh immutable tag, instead of silently re-pushing (and thus never
updating) the bare version tag.

Renovate's **default** docker versioning treats everything after the first dash as
an opaque compatibility suffix (like `-alpine`): it would neither move a `1.7.5`
pin onto `1.7.5-r1` nor bump `1.7.5-r1` → `1.7.5-r2`, leaving version-pinned
deployments stuck on a stale image.

## Change

Add a `packageRule` with **regex versioning** where the OSISM revision is captured
as the `build` group (handled like `patch`) and the `-r` part is optional:

```
versioning: regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?:-r(?<build>\d+))?$
```

With this, Renovate parses a bare `X.Y.Z` pin (build absent), upgrades it to
`X.Y.Z-r1` (no manual edit needed), then auto-tracks revision bumps (`1.7.5-r2`)
and future upstream bumps (`1.7.6-r1`). Tags that don't match (`latest`, `-alpine`
variants, date-based osism tags) are ignored.

The rule is deliberately scoped to `registry.osism.tech/osism/ara-server`, **not**
`registry.osism.tech/osism/**`, because most OSISM images use date-based or codename
tags this regex would reject. Other write-once images that adopt the `-rN` scheme
(netbox, openstackclient, cephclient, ceph-daemon) should be added to
`matchPackageNames` as they migrate.

## Relationship to osism/container-images#942

This rule is **backward-compatible and safe to merge on its own** — it does not
depend on #942. The `-r` group is optional, so it matches both old-style `1.7.5`
and `-rN` tags; with only old-style tags in the registry (today) the highest match
equals the current pin, so it is a no-op.

It should simply be **in place before Renovate first encounters a `-rN` tag** (merge
before or together with the companion). If a `-rN` tag were pushed while this rule
is absent, Renovate would treat `-rN` as an opaque variant and not adopt it — no
breakage, the fix just wouldn't auto-propagate until this lands.

- osism/container-images#942

🤖 Generated with [Claude Code](https://claude.com/claude-code)
