### PR TITLE
Exempt osism/* source repos from release-age delay

### DIFF
--- a/default.json
+++ b/default.json
@@ -16,6 +16,7 @@
       "matchPackageNames": [
         "osism",
         "osism.*",
+        "osism/**",
         "netbox-manager",
         "openstack-image-manager",
         "openstack-flavor-manager",


### PR DESCRIPTION
## What

Add the `osism/**` glob to the `matchPackageNames` of the "exempt OSISM's own releases from the 3-day delay" rule in `default.json`.

## Why

The exemption rule sets `minimumReleaseAge: null` so OSISM's own releases bump without the global 3-day delay. Its patterns matched:

- `osism` — the bare package
- `osism.*` — the Galaxy collections (`osism.commons`, `osism.services`, `osism.validations`)
- `registry.osism.tech/osism/**` — the OSISM Docker images

…but **not** the `osism/<name>` github-tags dependencies. So OSISM's own source repos were still held back by the 3-day delay, contrary to the rule's intent:

- osism/defaults
- osism/generics
- osism/ansible-playbooks
- osism/ansible-playbooks-manager
- osism/kolla-operations

The existing patterns can't match them: `osism` is exact, `osism.*` is a glob whose `*` doesn't cross `/` (and wants a literal dot), and the registry pattern targets a different prefix.

## How

`osism/**` uses `**`, which crosses path separators, so all `osism/<name>` deps are exempted and bump immediately like the other OSISM-owned artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)