### PR TITLE
ansibleCollection: cap ansible test pin below 13

### DIFF
--- a/ansibleCollection.json
+++ b/ansibleCollection.json
@@ -16,7 +16,9 @@
    "packageRules":[
       {
          "matchFileNames": ["**/.zuul.yaml"],
-         "groupName": "test-role"
+         "groupName": "test-role",
+         "description": "ansible_molecule_ansible_version installs the molecule control node on the CI test nodes, one of which (debian-bookworm) ships system Python 3.11. ansible >=13 requires Python >=3.12, so bumps to 13/14 cannot install there and red the whole buildset. Cap at <13 until every molecule node provides Python 3.12 (drop bookworm or install 3.12 there).",
+         "allowedVersions": "<13"
       }
    ]
 }


### PR DESCRIPTION
The `ansibleCollection` customManager bumps `ansible_molecule_ansible_version`
in each collection's `.zuul.yaml` as the PyPI `ansible` package with no
ceiling, so Renovate proposes the latest major. ansible >=13 requires
Python >=3.12, but one molecule test node (`debian-bookworm`) ships system
Python 3.11 — so v13/v14 bumps cannot install there and red the entire
buildset.

Add `allowedVersions: "<13"` to the `.zuul.yaml` packageRule so Renovate
tracks the newest installable major (12.x). Scoped to `.zuul.yaml`, so it
does not affect other ansible pins (e.g. runtime wrappers) in the extending
repos. Lift the cap once every molecule node provides Python 3.12.

Part of:

- osism/issues#1418

🤖 Generated with [Claude Code](https://claude.com/claude-code)
